### PR TITLE
feat: add version command with build-time injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,14 @@ This is a fork of [alexaandru/go3up](https://github.com/alexaandru/go3up) mainta
 
 ## Building and Testing
 
-Build the binary:
+Build the binary with version information:
+```bash
+make build
+```
+
+The Makefile automatically injects version information from git (commit hash, tags, and build date).
+
+Build directly with go (without version info):
 ```bash
 go build
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
+# Version information
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+
+LDFLAGS := -X 'main.Version=$(VERSION)' \
+           -X 'main.GitCommit=$(GIT_COMMIT)' \
+           -X 'main.BuildDate=$(BUILD_DATE)'
+
 build:
-	@go build
+	@go build -ldflags "$(LDFLAGS)"
 
 test:
 	@AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/README.md
+++ b/README.md
@@ -24,8 +24,30 @@ locally, yet).
 Run `go-s3-uploader -h` to get the help. You can save your preferences to a .go-s3-uploader.json config file by
 passing your command line flags as usual and adding "-save" at the end.
 
+Check the version with `go-s3-uploader -version` to see the build version, git commit, and build date.
+
 For authentication, see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
 as we pretty much support all of those options, in this order: shared profile; EC2 role; env vars.
+
+## Building
+
+Build the binary with version information:
+
+```bash
+make build
+```
+
+The build process automatically injects version information from git (commit hash, tags, and build date). If you want to specify a custom version:
+
+```bash
+make build VERSION=1.0.0
+```
+
+Or build directly with `go build`:
+
+```bash
+go build -ldflags "-X 'main.Version=1.0.0' -X 'main.GitCommit=$(git rev-parse --short HEAD)' -X 'main.BuildDate=$(date -u '+%Y-%m-%d_%H:%M:%S')'"
+```
 
 ## Migration from go3up
 

--- a/opts.go
+++ b/opts.go
@@ -18,7 +18,7 @@ type options struct {
 	Encrypt      bool `json:"encrypt,omitempty"`
 
 	dryRun, verbose, quiet,
-	doCache, doUpload, saveCfg bool
+	doCache, doUpload, saveCfg, version bool
 }
 
 func (o *options) dump(fname string) error {

--- a/setup.go
+++ b/setup.go
@@ -65,6 +65,7 @@ func processCmdLineFlags(opts *options) {
 	flag.BoolVar(&opts.doCache, "cache", opts.doCache, "Do update the cache")
 	flag.BoolVar(&opts.Encrypt, "encrypt", opts.Encrypt, "Encrypt files on server side")
 	flag.BoolVar(&opts.saveCfg, "save", opts.saveCfg, "Saves the current commandline options to a config file")
+	flag.BoolVar(&opts.version, "version", opts.version, "Print version information and exit")
 	flag.Parse()
 }
 
@@ -148,6 +149,13 @@ func init() {
 		abort(err)
 	}
 	processCmdLineFlags(opts)
+
+	// Handle version flag early, before AWS initialization
+	if opts.version {
+		fmt.Println(GetVersion())
+		os.Exit(Success)
+	}
+
 	if opts.cfgFile != oldCfgFile { // we were given a different config file, use that instead.
 		if err := opts.restore(opts.cfgFile); err != nil {
 			abort(err)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+var (
+	// Version is the semantic version number
+	Version = "dev"
+	// GitCommit is the git commit SHA
+	GitCommit = "unknown"
+	// BuildDate is the date the binary was built
+	BuildDate = "unknown"
+)
+
+// GetVersion returns the full version string
+func GetVersion() string {
+	return fmt.Sprintf("go-s3-uploader version %s (commit: %s, built: %s)", Version, GitCommit, BuildDate)
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	version := GetVersion()
+
+	if !strings.Contains(version, "go-s3-uploader version") {
+		t.Errorf("Expected version string to contain 'go-s3-uploader version', got: %s", version)
+	}
+
+	if !strings.Contains(version, "commit:") {
+		t.Errorf("Expected version string to contain 'commit:', got: %s", version)
+	}
+
+	if !strings.Contains(version, "built:") {
+		t.Errorf("Expected version string to contain 'built:', got: %s", version)
+	}
+}
+
+func TestVersionVariables(t *testing.T) {
+	// In test environment, these should have default values unless set at build time
+	if Version == "" {
+		t.Error("Version should not be empty")
+	}
+
+	if GitCommit == "" {
+		t.Error("GitCommit should not be empty")
+	}
+
+	if BuildDate == "" {
+		t.Error("BuildDate should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `-version` flag to display version information (semantic version, git commit, build date)
- Version information is injected at build time via ldflags in the Makefile
- Creates new `version.go` with version variables and `GetVersion()` function
- Updates Makefile to automatically extract version from git tags/commits
- Adds comprehensive tests in `version_test.go`
- Version flag exits early before AWS initialization for better UX

## Test plan

- [x] Build with `make build` and verify version displays correctly
- [x] Test `./go-s3-uploader -version` shows proper format
- [x] Test custom version with `VERSION=v1.0.0 make build`
- [x] Verify all existing tests pass with `make test`
- [x] Verify version flag appears in help output (`-h`)
- [x] Confirm version tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` command-line flag to display application version information, including commit hash and build date.
  * Build process now automatically embeds version metadata at compile time.

* **Documentation**
  * Updated building and installation documentation to reflect new versioning capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->