### PR TITLE
fix: skip AWS initialization in test mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
         run: go mod verify
 
       - name: Run tests
-        run: |
-          AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret \
-          go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ Build the binary:
 go build
 ```
 
-Run tests (requires mock AWS credentials):
+Run tests:
 ```bash
-AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 ```
 
 Run tests with coverage report:
@@ -73,5 +73,5 @@ Example run with test data:
 ## Testing Notes
 
 - Tests use `appEnv = "test"` to mock S3 operations and disable retry delays
-- Mock AWS credentials required: `AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret`
+- AWS initialization is skipped in test mode (detected via `-test.` flags)
 - Test data in `test/` directory with sample cache files

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ build:
 	@go build
 
 test:
-	@AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	@go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 run: build
 	@./go-s3-uploader -bucket="s3.ungur.ro" -source=test/output -cachefile=test/.go3up.txt
 
 cover:
-	@AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test -coverprofile=coverage.out
+	@go test -coverprofile=coverage.out
 	@go tool cover -html=coverage.out
 
 clean:

--- a/setup.go
+++ b/setup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,6 +15,17 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
+
+// isTestMode checks if the program is running under go test
+func isTestMode() bool {
+	// Check if running under go test by looking for test flags
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "-test.") {
+			return true
+		}
+	}
+	return false
+}
 
 var opts = &options{
 	WorkersCount: runtime.NumCPU() * 2,
@@ -143,6 +155,12 @@ func abort(msg error) {
 }
 
 func init() {
+	// Skip full initialization in test mode - tests will set up their own mocks
+	if isTestMode() {
+		say = loggerGen()
+		return
+	}
+
 	oldCfgFile := opts.cfgFile
 	if err := opts.restore(opts.cfgFile); err != nil {
 		abort(err)


### PR DESCRIPTION
## Summary

- Add `isTestMode()` function that detects test execution by checking for `-test.*` flags in `os.Args`
- Skip AWS client initialization when running under `go test`
- Remove dummy AWS credentials (`AWS_SECRET_ACCESS_KEY`/`AWS_ACCESS_KEY_ID`) from Makefile and CI workflow

## Test plan

- [x] Verify tests pass without setting AWS credentials: `go test -race ./...`
- [x] Verify `make test` works without credentials
- [x] Verify build still works: `go build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified test execution by removing AWS credential requirements—tests now run without manual credential setup.

* **Documentation**
  * Updated testing instructions to reflect that AWS initialization is skipped in test mode.

* **Chores**
  * Updated CI workflow and build configuration to remove unnecessary credential environment variables from test targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->